### PR TITLE
Fixes #7: make option list readable in Firefox when parent has dark b…

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -13,18 +13,31 @@ label {
 	color:#777;
 }
 
+.dark-wrapper {
+	margin-top: 2em;
+	padding: 1em 1em 1em;
+	background: #444;
+}
+
+.dark-wrapper label {
+	margin-top: 0;
+	color: #ccc;
+}
+
+
 /* These are the "theme" styles for our button applied via separate button class, style as you like */
+/* Set the background fallback to solid #fff so Firefox renders the <option> list readably. */
 .button {
 	border: 1px solid #bbb;
 	border-radius: .3em;
 	box-shadow: 0 1px 0 1px rgba(0,0,0,.04);
 	background: #f3f3f3; /* Old browsers */
-	background: -moz-linear-gradient(top, #ffffff 0%, #e5e5e5 100%); /* FF3.6+ */
-	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ffffff), color-stop(100%,#e5e5e5)); /* Chrome,Safari4+ */
-	background: -webkit-linear-gradient(top, #ffffff 0%,#e5e5e5 100%); /* Chrome10+,Safari5.1+ */
-	background: -o-linear-gradient(top, #ffffff 0%,#e5e5e5 100%); /* Opera 11.10+ */
-	background: -ms-linear-gradient(top, #ffffff 0%,#e5e5e5 100%); /* IE10+ */
-	background: linear-gradient(to bottom, #ffffff 0%,#e5e5e5 100%); /* W3C */
+	background: #fff -moz-linear-gradient(top, #ffffff 0%, #e5e5e5 100%); /* FF3.6+ */
+	background: #fff -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ffffff), color-stop(100%,#e5e5e5)); /* Chrome,Safari4+ */
+	background: #fff -webkit-linear-gradient(top, #ffffff 0%,#e5e5e5 100%); /* Chrome10+,Safari5.1+ */
+	background: #fff -o-linear-gradient(top, #ffffff 0%,#e5e5e5 100%); /* Opera 11.10+ */
+	background: #fff -ms-linear-gradient(top, #ffffff 0%,#e5e5e5 100%); /* IE10+ */
+	background: #fff linear-gradient(to bottom, #ffffff 0%,#e5e5e5 100%); /* W3C */
 }
 .custom-select {
 	margin-top: 0.5em;

--- a/demo/index.html
+++ b/demo/index.html
@@ -91,7 +91,7 @@
 	<option value="WI">Wisconsin</option>
 	<option value="WY">Wyoming</option>
 </select>
-</div>  
+</div>
 
 <div style="width:50%; min-width:10em;">
 <label class="wrapper">In 50% wide container
@@ -119,9 +119,25 @@
 </div> inline-block
 </label>
 
-<label>Text input: 
+<label>Text input:
 	<input type="text" placeholder="I'm a placeholder">
 </label>
+
+
+<div class="dark-wrapper">
+	<label>Test over a dark parent background
+	<div class="button custom-select">
+		<select>
+			<option>Apples</option>
+			<option>Bananas</option>
+			<option>Grapes</option>
+			<option>Oranges</option>
+			<option>A very long option name to test wrapping and visual collisions</option>
+		</select>
+	</div>
+	</label>
+	</div>
+</div>
 
 
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -139,6 +139,13 @@
 	</div>
 </div>
 
+<p style="font-size: 0.8rem;">
+	Note: in Firefox, using gradients on the <code>&lt;select&gt;</code> background
+	without a solid fallback color can make the option list unreadable.
+	<a href="https://github.com/filamentgroup/select-css/pull/14">See pull request #14</a>
+	for details.
+</p>
+
 
 </body>
 </html>


### PR DESCRIPTION
Resolves issue #7. In Firefox the option list inherits the background color of the closest ancestor that has a solid background color. If the `.custom-select` wrapper uses a dark solid background or only uses a gradient, then Firefox traces up through its ancestors until a solid color is found. If that color is dark then the option list is unreadable in Firefox (black text on dark background).

By setting a solid fallback of `#fff` on the `.custom-select` (or in the demo's case: `.button`) Firefox will render the option list readably (black text on white background).

I updated the demo to include a dark parent example. The issue can be reproduced by modifying the CSS for `.button` to remove the solid background fallback in the gradient declaration.