### PR TITLE
Fix #17: compilation issues with gulp-sass + gulp-autoprefixer

### DIFF
--- a/src/select-css.css
+++ b/src/select-css.css
@@ -36,12 +36,11 @@
 	display: none;
 }
 
-@supports ( -webkit-appearance: none ) or ( appearance: none )
-	/* Firefox <= 34 has a false positive on @supports( -moz-appearance: none )
-	 * @supports ( mask-type: alpha ) is Firefox 35+
-	 */
-	or ( ( -moz-appearance: none ) and ( mask-type: alpha ) ) {
-	
+/* Firefox <= 34 has a false positive on @supports( -moz-appearance: none )
+ * @supports ( mask-type: alpha ) is Firefox 35+
+ */
+@supports (-webkit-appearance: none) or (appearance: none) or ((-moz-appearance: none) and (mask-type: alpha)) {
+
 	/* Show custom arrow */
 	.custom-select::after {
 		display: block;


### PR DESCRIPTION
gulp-sass (node-sass) can’t compile with the multi-line @supports rule.

Moving the comment above `@supports` and making the rule a single line allows node-sass to compile it properly.
