### PR TITLE
RTL, Arabic, Hebrew support

### DIFF
--- a/src/select-css.css
+++ b/src/select-css.css
@@ -52,3 +52,9 @@
 .select-css option {
 	font-weight:normal;
 }
+
+/* Support for rtl text, explicit support for Arabic and Hebrew */
+*[dir="rtl"] .select-css, :root:lang(ar) .select-css, :root:lang(iw) .select-css {
+	background-position: left .7em top 50%, 0 0;
+	padding: .6em .8em .5em 1.4em;
+}


### PR DESCRIPTION
The arrow sits on the right, but in a native select in Arabic, Hebrew, or any right-to-left text the arrow is on the left in a native unstyled select.