### PR TITLE
Disabled styles

### DIFF
--- a/src/select-css.css
+++ b/src/select-css.css
@@ -58,3 +58,14 @@
 	background-position: left .7em top 50%, 0 0;
 	padding: .6em .8em .5em 1.4em;
 }
+
+/* Disabled styles */
+.select-css:disabled, .select-css[aria-disabled=true] {
+	color: graytext;
+	background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22graytext%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
+	  linear-gradient(to bottom, #ffffff 0%,#e5e5e5 100%);
+}
+
+.select-css:disabled:hover, .select-css[aria-disabled=true] {
+	border-color: #aaa;
+}


### PR DESCRIPTION
This uses `graytext` as the color keyword for both the text color and SVG arrow fill. It also removes the border color change on hover, which can otherwise indicate it is still interactive.

Because many accessibility best practices rely on `aria-disabled` I also added that as a selector. If nothing else, it is a visual reminder to developers who forget to toggle `aria-disabled` when they set `disabled`.

Tested in Firefox, Edge, Internet Explorer and Chrome all on Windows. No Mac handy today to test.