### PR TITLE
Fix missing hover pseudo-class

### DIFF
--- a/src/select-css.css
+++ b/src/select-css.css
@@ -66,6 +66,6 @@
 	  linear-gradient(to bottom, #ffffff 0%,#e5e5e5 100%);
 }
 
-.select-css:disabled:hover, .select-css[aria-disabled=true] {
+.select-css:disabled:hover, .select-css[aria-disabled=true]:hover {
 	border-color: #aaa;
 }


### PR DESCRIPTION
The `:hover` pseudo-class seems to be missing at the end of the `.select-css:disabled:hover, .select-css[aria-disabled=true]` selector.